### PR TITLE
Allow FLAME 0.5.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule FlameK8sBackend.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:flame, "~> 0.4.0"},
+      {:flame, "~> 0.4.0 or ~> 0.5.0"},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:mix_test_watch, "~> 1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},


### PR DESCRIPTION
FLAME [0.5.0](https://github.com/phoenixframework/flame/blob/main/CHANGELOG.md#050-2024-09-11) has just been released with a few changes to code sync. I want to bump FLAME in kino_flame to update the generated code, and so we need a compatible `flame_k8s_backend` as a dependency :)