### PR TITLE
Add support for passing secret env variables as Kubernetes secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 <!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
 
+### Added
+
+* Support for secret env variables. Env variables passed via `:secret_env` will be
+  added to a Kubernetes secret rather than passed in the Pod manifest. [#159](https://github.com/mruoss/flame_k8s_backend/pull/159)
+
+### Changed
+
+* ⚠️ With this release, the service account running the main pod needs CRUD 
+  permissions on Kubernetes secrets. Check the README for RBAC instructions.
+* Pass `RELEASE_COOKIE` via Kubernetes secret to the runner pod.
+
 <!--------------------- Don't add new entries after this line --------------------->
 
 ## [0.6.0] - 2026-03-06

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["create", "get", "list", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "list", "delete", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/lib/flame_k8s_backend.ex
+++ b/lib/flame_k8s_backend.ex
@@ -36,6 +36,10 @@ defmodule FLAMEK8sBackend do
       runner. When specified, these environment variables take precendence over
       the ones defined in `:manifest`. This option is a convenience for passing
       extra values read at runtime.
+      See the "Manifest configuration" section below for more details.
+
+    * `:secret_env` - Same as `:env` but these will be applied as a Kubernets
+      secret and appended to the Pod via `envFrom`.
 
     * `:app_container_name` - If your application pod runs multiple containers
       (initContainers excluded), use this option to pass the name of the
@@ -267,17 +271,16 @@ defmodule FLAMEK8sBackend do
   require Logger
 
   defstruct runner_pod_manifest: nil,
+            runner_secret_manifest: nil,
             parent_ref: nil,
             runner_node_name: nil,
-            manifest: nil,
-            env: nil,
             boot_timeout: nil,
             remote_terminator_pid: nil,
-            omit_owner_reference: false,
             log: false,
-            http: nil
+            http: nil,
+            app_container_access: nil
 
-  @valid_opts ~w(app_container_name manifest env terminator_sup log boot_timeout omit_owner_reference)a
+  @valid_opts ~w(app_container_name manifest env secret_env terminator_sup log boot_timeout omit_owner_reference)a
   @required_config ~w()a
 
   @impl true
@@ -306,18 +309,32 @@ defmodule FLAMEK8sBackend do
 
     http = K8sClient.connect()
 
+    app_container_access =
+      case provided_opts[:app_container_name] do
+        nil -> ["spec", "containers"]
+        name -> ["spec", "containers", Access.filter(&(&1["name"] == name))]
+      end
+
     case K8sClient.get_pod(http, System.get_env("POD_NAMESPACE"), System.get_env("POD_NAME")) do
       {:ok, base_pod} ->
         new_state =
           struct(state,
             http: http,
             parent_ref: parent_ref,
+            app_container_access: app_container_access,
             runner_pod_manifest:
-              RunnerPodTemplate.manifest(
+              RunnerPodTemplate.pod_manifest(
                 base_pod,
                 provided_opts[:manifest] || %{},
                 parent_ref,
-                Keyword.take(provided_opts, [:env, :app_container_name, :omit_owner_reference])
+                app_container_access,
+                Keyword.take(provided_opts, [:env, :omit_owner_reference])
+              ),
+            runner_secret_manifest:
+              RunnerPodTemplate.secret_manifest(
+                base_pod,
+                Keyword.get(provided_opts, :secret_env, %{}),
+                Keyword.take(provided_opts, [:omit_owner_reference])
               )
           )
 
@@ -362,15 +379,23 @@ defmodule FLAMEK8sBackend do
 
     {new_state, req_connect_time} =
       with_elapsed_ms(fn ->
-        created_pod =
-          K8sClient.create_pod!(state.http, state.runner_pod_manifest, state.boot_timeout)
+        with {:ok, applied_secret} <-
+               K8sClient.create_secret!(state.http, state.runner_secret_manifest),
+             {:ok, runner_pod_manifest} <-
+               RunnerPodTemplate.add_env_secret(
+                 state.runner_pod_manifest,
+                 applied_secret,
+                 state.app_container_access
+               ),
+             {:ok, pod} <-
+               K8sClient.create_pod!(state.http, runner_pod_manifest, state.boot_timeout) do
+          log(state, "Runner pod and secret created and scheduled",
+            pod_ip: pod["status"]["podIP"]
+          )
 
-        case created_pod do
-          {:ok, pod} ->
-            log(state, "Runner pod created and scheduled", pod_ip: pod["status"]["podIP"])
-            state
-
-          :error ->
+          state
+        else
+          {:error, :timeout} ->
             Logger.error("failed to schedule runner pod within #{state.boot_timeout}ms")
             exit(:timeout)
         end

--- a/lib/flame_k8s_backend/k8s_client.ex
+++ b/lib/flame_k8s_backend/k8s_client.ex
@@ -44,7 +44,18 @@ defmodule FLAMEK8sBackend.K8sClient do
     wait_until_scheduled(http, namespace, name, timeout)
   end
 
-  defp wait_until_scheduled(_req, _namespace, _name, timeout) when timeout <= 0, do: :error
+  def delete_secret!(http, namespace, name) do
+    HTTP.delete!(http, secret_path(namespace, name))
+  end
+
+  def create_secret!(http, secret) do
+    namespace = secret["metadata"]["namespace"]
+    created_secret = HTTP.post!(http, secret_path(namespace, ""), JSON.encode!(secret))
+    {:ok, created_secret}
+  end
+
+  defp wait_until_scheduled(_req, _namespace, _name, timeout) when timeout <= 0,
+    do: {:error, :timeout}
 
   defp wait_until_scheduled(req, namespace, name, timeout) do
     case get_pod!(req, namespace, name) do
@@ -59,5 +70,9 @@ defmodule FLAMEK8sBackend.K8sClient do
 
   defp pod_path(namespace, name) do
     "/api/v1/namespaces/#{namespace}/pods/#{name}"
+  end
+
+  defp secret_path(namespace, name) do
+    "/api/v1/namespaces/#{namespace}/secrets/#{name}"
   end
 end

--- a/lib/flame_k8s_backend/runner_pod_template.ex
+++ b/lib/flame_k8s_backend/runner_pod_template.ex
@@ -5,18 +5,23 @@ defmodule FLAMEK8sBackend.RunnerPodTemplate do
   @type manifest :: map()
   @type callback :: (parent_pod_manifest() -> manifest())
 
-  @spec manifest(parent_pod_manifest(), manifest() | callback(), Keyword.t()) :: manifest()
-  def manifest(parent_pod_manifest, template_args_or_callback, parent_ref, opts \\ [])
+  def pod_manifest(
+        parent_pod_manifest,
+        template_args_or_callback,
+        parent_ref,
+        app_container_access,
+        opts \\ []
+      )
 
-  def manifest(parent_pod_manifest, template_callback, parent_ref, opts)
+  def pod_manifest(parent_pod_manifest, template_callback, parent_ref, app_container_access, opts)
       when is_function(template_callback) do
-    app_container = app_container(parent_pod_manifest, opts)
+    app_container = app_container(parent_pod_manifest, app_container_access)
     manifest = template_callback.(parent_pod_manifest, app_container)
-    manifest(parent_pod_manifest, manifest, parent_ref, opts)
+    pod_manifest(parent_pod_manifest, manifest, parent_ref, app_container_access, opts)
   end
 
-  def manifest(parent_pod_manifest, manifest, parent_ref, opts) do
-    app_container = app_container(parent_pod_manifest, opts)
+  def pod_manifest(parent_pod_manifest, manifest, parent_ref, app_container_access, opts) do
+    app_container = app_container(parent_pod_manifest, app_container_access)
 
     parent_pod_manifest_name = parent_pod_manifest["metadata"]["name"]
     parent_pod_manifest_namespace = parent_pod_manifest["metadata"]["namespace"]
@@ -61,7 +66,6 @@ defmodule FLAMEK8sBackend.RunnerPodTemplate do
           # Envs precendence: overridable defaults, template manifest, template :env, non-overridable.
           [
             %{"name" => "PHX_SERVER", "value" => "false"},
-            %{"name" => "RELEASE_COOKIE", "value" => Node.get_cookie()},
             %{"name" => "RELEASE_DISTRIBUTION", "value" => "name"},
             %{"name" => "RELEASE_NODE", "value" => "flame_runner@$(POD_IP)"}
           ]
@@ -87,6 +91,35 @@ defmodule FLAMEK8sBackend.RunnerPodTemplate do
     end)
   end
 
+  def secret_manifest(parent_pod_manifest, secret_env, opts) do
+    object_references =
+      if opts[:omit_owner_reference],
+        do: [],
+        else: object_references(parent_pod_manifest)
+
+    %{
+      "apiVersion" => "v1",
+      "kind" => "Secret",
+      "metadata" => %{
+        "namespace" => parent_pod_manifest["metadata"]["namespace"],
+        "generateName" => parent_pod_manifest["metadata"]["name"] <> "-",
+        "ownerReferences" => object_references
+      },
+      "stringData" => Map.merge(secret_env, %{"RELEASE_COOKIE" => Node.get_cookie()})
+    }
+  end
+
+  def add_env_secret(pod_manifest, secret_manifest, app_container_access) do
+    pod_manifest =
+      pod_manifest
+      |> update_in(app_container_access ++ [Access.at(0), "envFrom"], fn env_from ->
+        secret_ref = secret_manifest |> Map.fetch!("metadata") |> Map.take(["name", "namespace"])
+        [%{"secretRef" => secret_ref} | List.wrap(env_from)]
+      end)
+
+    {:ok, pod_manifest}
+  end
+
   defp merge_env([], right), do: right
 
   defp merge_env(left, right) do
@@ -105,15 +138,9 @@ defmodule FLAMEK8sBackend.RunnerPodTemplate do
     left ++ right
   end
 
-  defp app_container(parent_pod_manifest, opts) do
-    container_access =
-      case opts[:app_container_name] do
-        nil -> []
-        name -> [Access.filter(&(&1["name"] == name))]
-      end
-
+  defp app_container(parent_pod_manifest, app_container_access) do
     parent_pod_manifest
-    |> get_in(["spec", "containers" | container_access])
+    |> get_in(app_container_access)
     |> List.first()
   end
 

--- a/test/flame_k8s_backend/runner_pod_template_test.exs
+++ b/test/flame_k8s_backend/runner_pod_template_test.exs
@@ -15,17 +15,22 @@ defmodule FLAMEK8sBackend.RunnerPodTemplateTest do
   end
 
   defp env_var_access(name) do
-    app_container_access(["env", Access.filter(&(&1["name"] == name)), "value"])
+    app_container_access_first(["env", Access.filter(&(&1["name"] == name)), "value"])
   end
 
-  defp app_container_access(field \\ []),
+  defp app_container_access_first(field \\ []),
     do: ["spec", "containers", Access.at(0)] ++ List.wrap(field)
+
+  defp app_container_access(field \\ []), do: ["spec", "containers"] ++ List.wrap(field)
+
+  defp named_app_container_access(name, field \\ []),
+    do: ["spec", "containers", Access.filter(&(&1["name"] == name))] ++ List.wrap(field)
 
   setup_all do
     [parent_pod_manifest_full: Pods.parent_pod_manifest_full()]
   end
 
-  describe "manifest/2" do
+  describe "pod_manifest/5" do
     alias FLAMEK8sBackend.TestSupport.Pods
 
     test "should return pod manifest with data form callback", %{
@@ -33,7 +38,7 @@ defmodule FLAMEK8sBackend.RunnerPodTemplateTest do
     } do
       callback = fn parent_manifest, app_container ->
         assert parent_manifest == parent_pod_manifest
-        assert get_in(parent_manifest, app_container_access()) == app_container
+        assert get_in(parent_manifest, app_container_access_first()) == app_container
 
         ~y"""
         metadata:
@@ -49,12 +54,13 @@ defmodule FLAMEK8sBackend.RunnerPodTemplateTest do
                   value: "bar"
         """
         |> put_in(
-          app_container_access(~w(resources requests)),
-          get_in(parent_manifest, app_container_access(~w(resources requests)))
+          app_container_access_first(~w(resources requests)),
+          get_in(parent_manifest, app_container_access_first(~w(resources requests)))
         )
       end
 
-      pod_manifest = MUT.manifest(parent_pod_manifest, callback, make_ref())
+      pod_manifest =
+        MUT.pod_manifest(parent_pod_manifest, callback, make_ref(), app_container_access())
 
       # sets defaults for required ENV vars
       assert get_in(pod_manifest, env_var_access("PHX_SERVER")) == ["false"]
@@ -63,8 +69,12 @@ defmodule FLAMEK8sBackend.RunnerPodTemplateTest do
 
       # from the callback
       assert get_in(pod_manifest, env_var_access("FOO")) == ["bar"]
-      assert get_in(pod_manifest, app_container_access(~w(resources requests memory))) == "100Mi"
-      assert get_in(pod_manifest, app_container_access(~w(resources limits memory))) == "500Mi"
+
+      assert get_in(pod_manifest, app_container_access_first(~w(resources requests memory))) ==
+               "100Mi"
+
+      assert get_in(pod_manifest, app_container_access_first(~w(resources limits memory))) ==
+               "500Mi"
     end
 
     test "should add default data to pod manifest", %{
@@ -81,8 +91,10 @@ defmodule FLAMEK8sBackend.RunnerPodTemplateTest do
                 cpu: 500
       """
 
-      pod_manifest = MUT.manifest(parent_pod_manifest, manifest, make_ref())
-      assert get_in(pod_manifest, app_container_access() ++ ["image"]) == "flame-test-image:0.1.0"
+      pod_manifest =
+        MUT.pod_manifest(parent_pod_manifest, manifest, make_ref(), app_container_access())
+
+      assert get_in(pod_manifest, app_container_access_first("image")) == "flame-test-image:0.1.0"
 
       owner_references = get_in(pod_manifest, ~w(metadata ownerReferences))
       assert length(owner_references) == 1
@@ -106,11 +118,15 @@ defmodule FLAMEK8sBackend.RunnerPodTemplateTest do
       """
 
       pod_manifest =
-        MUT.manifest(parent_pod_manifest, manifest, make_ref(),
+        MUT.pod_manifest(
+          parent_pod_manifest,
+          manifest,
+          make_ref(),
+          named_app_container_access("other-container"),
           app_container_name: "other-container"
         )
 
-      assert get_in(pod_manifest, app_container_access() ++ ["image"]) == "other-image:0.1.0"
+      assert get_in(pod_manifest, app_container_access_first("image")) == "other-image:0.1.0"
     end
 
     test "should not add ownerReferences if omitted", %{
@@ -128,7 +144,9 @@ defmodule FLAMEK8sBackend.RunnerPodTemplateTest do
       """
 
       pod_manifest =
-        MUT.manifest(parent_pod_manifest, manifest, make_ref(), omit_owner_reference: true)
+        MUT.pod_manifest(parent_pod_manifest, manifest, make_ref(), app_container_access(),
+          omit_owner_reference: true
+        )
 
       assert [] == get_in(pod_manifest, ~w(metadata ownerReferences))
     end
@@ -149,7 +167,9 @@ defmodule FLAMEK8sBackend.RunnerPodTemplateTest do
       env = %{"BAR" => "bar_from_env_opt", "FLAME_PARENT" => "foo"}
 
       ref = make_ref()
-      pod_manifest = MUT.manifest(parent_pod_manifest, manifest, ref, env: env)
+
+      pod_manifest =
+        MUT.pod_manifest(parent_pod_manifest, manifest, ref, app_container_access(), env: env)
 
       # FOO comes from manifest, overriding the overridable default
       assert get_in(pod_manifest, env_var_access("PHX_SERVER")) == ["true"]
@@ -161,6 +181,31 @@ defmodule FLAMEK8sBackend.RunnerPodTemplateTest do
       # FLAME_PARENT from :env is ignored, keeping the expected value
       parent = flame_parent(pod_manifest)
       assert parent.ref == ref
+    end
+  end
+
+  describe "secret_manifest/3" do
+    alias FLAMEK8sBackend.TestSupport.Pods
+
+    test "adds secrets", %{parent_pod_manifest_full: parent_pod_manifest} do
+      secret_manifest =
+        MUT.secret_manifest(parent_pod_manifest, %{"FOO" => "bar", "BAR" => "foo"}, [])
+
+      assert "bar" == get_in(secret_manifest, ~w(stringData FOO))
+      assert "foo" == get_in(secret_manifest, ~w(stringData BAR))
+      assert :nocookie == get_in(secret_manifest, ~w(stringData RELEASE_COOKIE))
+      refute [] == get_in(secret_manifest, ~w(metadata ownerReferences))
+    end
+
+    test "should not add ownerReferences if omitted", %{
+      parent_pod_manifest_full: parent_pod_manifest
+    } do
+      secret_manifest =
+        MUT.secret_manifest(parent_pod_manifest, %{"FOO" => "bar", "BAR" => "foo"},
+          omit_owner_reference: true
+        )
+
+      assert [] == get_in(secret_manifest, ~w(metadata ownerReferences))
     end
   end
 end

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -75,7 +75,10 @@ defmodule FlameK8sBackend.IntegrationTest do
   @tag :integration
   test "Pod shows the log statement with the result of the first runner" do
     assert :ok ==
-             assert_logs_eventually(~r/Result is \{"foo_from_manifest", "bar_from_env"\}/, 30_000),
+             assert_logs_eventually(
+               ~r/Result is \{"foo_from_manifest", "bar_from_env", "bar_from_secret"\}/,
+               30_000
+             ),
            "Logs were not found"
   end
 end

--- a/test/integration/manifest.yaml
+++ b/test/integration/manifest.yaml
@@ -19,6 +19,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["create", "get", "list", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "list", "delete", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -54,7 +57,10 @@ spec:
       resources:
         requests:
           cpu: 300m
-          memory: 300Mi
+          memory: 2.5Gi
+        limits:
+          cpu: 300m
+          memory: 2.5Gi
       env:
         - name: POD_NAME
           valueFrom:

--- a/test_support/integration_test_runner.ex
+++ b/test_support/integration_test_runner.ex
@@ -17,6 +17,7 @@ defmodule FlameK8sBackend.IntegrationTestRunner do
     """
 
     env = %{"BAR" => "bar_from_env"}
+    secret_env = %{"BAR_SECRET" => "bar_from_secret"}
 
     children = [
       {
@@ -41,7 +42,7 @@ defmodule FlameK8sBackend.IntegrationTestRunner do
         boot_timeout: :timer.minutes(3),
         idle_shutdown_after: :timer.minutes(1),
         timeout: :infinity,
-        backend: {FLAMEK8sBackend, manifest: manifest, env: env},
+        backend: {FLAMEK8sBackend, manifest: manifest, env: env, secret_env: secret_env},
         track_resources: true,
         log: :debug
       }
@@ -55,7 +56,8 @@ defmodule FlameK8sBackend.IntegrationTestRunner do
 
     [
       {IntegrationTest.Runner, fn -> :flame_ok end},
-      {IntegrationTest.CallbackRunner, fn -> {System.get_env("FOO"), System.get_env("BAR")} end}
+      {IntegrationTest.CallbackRunner,
+       fn -> {System.get_env("FOO"), System.get_env("BAR"), System.get_env("BAR_SECRET")} end}
     ]
     |> Enum.map(fn {pool, fun} -> Task.async(fn -> FLAME.call(pool, fun) end) end)
     |> Task.await_many(:infinity)


### PR DESCRIPTION
Support for secret env variables. Env variables passed via `:secret_env` should be passed to the runner pod via Kubernetes secret.
